### PR TITLE
Update ngtimeago.js

### DIFF
--- a/ngtimeago.js
+++ b/ngtimeago.js
@@ -16,7 +16,7 @@ catalyst.filter('timeago', function() {
                 //refreshMillis= 6e4, //A minute
                 allowFuture = p_allowFuture || false,
                 strings= {
-                    prefixAgo: '',
+                    prefixAgo: ' ',
                     prefixFromNow: '',
                     suffixAgo: "ago",
                     suffixFromNow: "from now",
@@ -63,7 +63,7 @@ catalyst.filter('timeago', function() {
             days < 365 && substitute(strings.months, Math.round(days / 30), strings) ||
             years < 1.5 && substitute(strings.year, 1, strings) ||
             substitute(strings.years, Math.round(years), strings);
-			console.log(prefix+words+suffix+separator);
+			console.log(words+prefix+suffix);
 			prefix.replace(/ /g, '')
 			words.replace(/ /g, '')
 			suffix.replace(/ /g, '')


### PR DESCRIPTION
for some reason, the spacing got jumbled in the `console.log`. This makes the print statement more readable.