### PR TITLE
Removed the console.log in ngtimeago.js

### DIFF
--- a/ngtimeago.js
+++ b/ngtimeago.js
@@ -63,7 +63,6 @@ catalyst.filter('timeago', function() {
             days < 365 && substitute(strings.months, Math.round(days / 30), strings) ||
             years < 1.5 && substitute(strings.year, 1, strings) ||
             substitute(strings.years, Math.round(years), strings);
-			console.log(prefix+words+suffix+separator);
 			prefix.replace(/ /g, '')
 			words.replace(/ /g, '')
 			suffix.replace(/ /g, '')


### PR DESCRIPTION
Looks like a remnants of some test code and is clustering my console.
Fixes https://github.com/uttesh/ngtimeago/issues/10